### PR TITLE
Fixes to the SH-Macro-Parser branch

### DIFF
--- a/libMacGitverCore/SHMParser/ShellExpand.cpp
+++ b/libMacGitverCore/SHMParser/ShellExpand.cpp
@@ -303,7 +303,6 @@ QString ShellExpand::expandText(const QString &input)
     if (s.mode() == State::PlainText)
     {
         s.flush( s.get() );
-        s.advance( State::PlainText );
         return s.output();
     }
 

--- a/libMacGitverCore/SHMParser/ShellExpand.cpp
+++ b/libMacGitverCore/SHMParser/ShellExpand.cpp
@@ -281,10 +281,15 @@ QString ShellExpand::expandText(const QString &input)
                     s.advance(State::PlainText, false);
                     s.doSave();
                 }
+                else
+                {
+                    s.advance();
+                }
             }
             else if (s.cur() == L'{')
             {
                 s.recurseIn();
+                s.advance();
             }
             else
             {

--- a/libMacGitverCore/SHMParser/ShellExpand.cpp
+++ b/libMacGitverCore/SHMParser/ShellExpand.cpp
@@ -267,6 +267,7 @@ QString ShellExpand::expandText(const QString &input)
                 partCommand = s.get();
                 s.advance(State::ArgumentPart, true);
                 s.initRecursion();
+                s.recurseIn();
             }
             break;
 

--- a/libMacGitverCore/SHMParser/ShellExpand.cpp
+++ b/libMacGitverCore/SHMParser/ShellExpand.cpp
@@ -122,7 +122,7 @@ public:
      */
     inline void flush(const QString &part)
     {
-        mOutput += part;      
+        mOutput += part;
     }
 
     inline int recurseIn()

--- a/testMacGitverCore/Test_SHMParser.cpp
+++ b/testMacGitverCore/Test_SHMParser.cpp
@@ -22,7 +22,7 @@ TEST(SHMParser, RecursiveAssignMacro_Test)
     QString source = QString::fromUtf8("_${MacroOuter:=${MacroInner:=Recurse}}_");
     QString result = se.expandText(source);
 
-    ASSERT_STREQ("_RecurseRecurse_", qPrintable(result));
+    ASSERT_STREQ("_Recurse_", qPrintable(result));
 
     ShellExpand::Macros m = se.macros();
     ASSERT_EQ(2, m.count());


### PR DESCRIPTION
Contains:
- First commit sets the expected result right
- Second and Third commit fix two bugs that show up as "endless recursion", but are actually no recursion at all :-)
- Thrid removes an odd advance that nobody will ever care about
- And the final commit fixes some white space that Qt Creator automatically fixed up :)

By the way: The "artificial else-if construct" that you're using is hard to follow :) Actually, I know some people say the contrary. Just an opinion, though...
