### PR TITLE
Workaround to re-initialize Views after mode switch

### DIFF
--- a/libMacGitverCore/RepoMan/RepoMan.cpp
+++ b/libMacGitverCore/RepoMan/RepoMan.cpp
@@ -25,6 +25,8 @@
 #include "RepoMan/Private/RepoManPrivate.hpp"
 #include "RepoMan/Private/RepoPrivate.hpp"
 
+#include "libBlueSky/Application.hpp"
+
 namespace RM
 {
 
@@ -45,6 +47,11 @@ namespace RM
         : Base(*new RepoManPrivate(this))
     {
         Events::addReceiver(this);
+
+        connect(BlueSky::Application::instance(),
+                SIGNAL(activeModeChanged(BlueSky::Mode*)),
+                this,
+                SLOT(reactivateWorkaround()));
     }
 
     /**
@@ -147,6 +154,15 @@ namespace RM
 
         foreach(Repo* repo, d->repos) {
             repo->close();
+        }
+    }
+
+    void RepoMan::reactivateWorkaround()
+    {
+        RM_D(RepoMan);
+        if (d->activeRepo) {
+            Events::self()->repositoryDeactivated(d->activeRepo);
+            Events::self()->repositoryActivated(d->activeRepo);
         }
     }
 

--- a/libMacGitverCore/RepoMan/RepoMan.hpp
+++ b/libMacGitverCore/RepoMan/RepoMan.hpp
@@ -58,6 +58,9 @@ namespace RM
 
         void internalClosedRepo(Repo* repository);
 
+    private slots:
+        void reactivateWorkaround();
+
     private:
         bool refreshSelf();
         void preTerminate();


### PR DESCRIPTION
Until all Views are converted to Contexts and Contexts actually do work, we need to tell the Views that they have been recreated for them to be able to setup their content again...

@antis81, please review, try and merge :)
