### PR TITLE
fixed saving/restoring the main window's geometry on application start

### DIFF
--- a/libMacGitverCore/App/MgvPrimaryWindow.cpp
+++ b/libMacGitverCore/App/MgvPrimaryWindow.cpp
@@ -109,15 +109,8 @@ void MgvPrimaryWindow::showLater()
     }
     else
     {
-        QRect r = Config::self().get( "Geometry" ).toRect();
-        if( r.isEmpty() )
-        {
+        if (!restoreGeometry(Config::self().get("Geometry").toByteArray())) {
             moveToCenter();
-        }
-        else
-        {
-            resize( r.size() );
-            move( r.topLeft() );
         }
         show();
     }
@@ -127,7 +120,7 @@ void MgvPrimaryWindow::savePosition()
 {
     Config& c = Config::self();
     c.set( "FullScreen", isFullScreen() );
-    c.set( "Geometry", geometry() );
+    c.set( "Geometry", saveGeometry() );
     c.saveSettings();
 }
 


### PR DESCRIPTION
This is probably for Linux (X11) only:
On every start of MacGitver, the main window moves downwards by a fixed offset (the height of the title bar). This is in my case `18px`.

The reason for that is, that the "main widget" is surrounded by the window-frame, which is drawn "asynchronusly" (see Qt documentation [here](http://doc.qt.io/qt-5/application-windows.html) )

Qt's methods for saving & restoring the main window's geometry is working most reliable here.

Btw.: MacGitver is shown centered on the primary monitor in case, that reading the settings fails. The size is calculated, depending on the screen resolution. This is a good thing :+1:

@scunz Could you please chack, if that works on OSX?
