### PR TITLE
Drop Qt4 support - Part II

### DIFF
--- a/Modules/History/HistoryDiff.cpp
+++ b/Modules/History/HistoryDiff.cpp
@@ -79,10 +79,9 @@ HistoryDiff::HistoryDiff()
     mParentsList->setHeaderHidden( true );
     mParentsList->setRootIsDecorated( false );
 
-    #if QT_VERSION < 0x050000
-    // QT5: Recheck this.
-    mParentsList->header()->setResizeMode( QHeaderView::ResizeToContents );
-    #endif
+    // TODO: This has to be revisited. The "hidden date column" will be
+    // completely shown, when moving the mouse pointer to the right edge.
+    mParentsList->header()->setSectionResizeMode( QHeaderView::ResizeToContents );
 
     mParentsList->setModel( mParentsModel );
     mDiffToParent->setView( mParentsList );

--- a/Modules/Submodules/SubmodulesModule.cpp
+++ b/Modules/Submodules/SubmodulesModule.cpp
@@ -41,7 +41,3 @@ void SubmodulesModule::deinitialize()
 {
     unregisterView( "Submodules" );
 }
-
-#if QT_VERSION < 0x050000
-Q_EXPORT_PLUGIN2( Submodules, SubmodulesModule )
-#endif

--- a/Modules/WorkingTree/WorkingTreeModel.cpp
+++ b/Modules/WorkingTree/WorkingTreeModel.cpp
@@ -29,18 +29,7 @@
 
 QIcon getWindowsIcon( const QString& pathName )
 {
-#if QT_VERSION < QT_VERSION_CHECK(5,0,0)
-    SHFILEINFOW shfi;
-    memset( &shfi, 0, sizeof(shfi) );
-    DWORD flags = SHGFI_ICON | SHGFI_USEFILEATTRIBUTES | SHGFI_SMALLICON;
-    SHGetFileInfoW( (LPCWSTR) pathName.utf16(), FILE_ATTRIBUTE_NORMAL, &shfi, sizeof(shfi), flags );
-
-    QPixmap pm = QPixmap::fromWinHICON( shfi.hIcon );	// Undefined für Qt5!
-    DestroyIcon( shfi.hIcon );
-    return QIcon( pm );
-#else
     return QIcon();
-#endif
 }
 #endif
 

--- a/Modules/WorkingTree/WorkingTreeModel.cpp
+++ b/Modules/WorkingTree/WorkingTreeModel.cpp
@@ -23,15 +23,6 @@
 #include "WorkingTreeDirItem.h"
 #include "WorkingTreeFileItem.h"
 
-#ifdef Q_OS_WIN
-
-#include <windows.h>
-
-QIcon getWindowsIcon( const QString& pathName )
-{
-    return QIcon();
-}
-#endif
 
 WorkingTreeModel::WorkingTreeModel(QObject* parent )
     : QAbstractItemModel( parent )
@@ -225,7 +216,7 @@ void WorkingTreeModel::update()
         QFileInfo fi( mRepo.basePath() + L'/' + it.key() );
 
 #ifdef Q_OS_WIN
-        file->setIcon( getWindowsIcon( fi.absoluteFilePath() ) );
+        file->setIcon( QIcon() );
 #else
         file->setIcon( ip.icon( fi ) );
 #endif

--- a/Modules/WorkingTree/WorkingTreeModel.cpp
+++ b/Modules/WorkingTree/WorkingTreeModel.cpp
@@ -24,6 +24,25 @@
 #include "WorkingTreeFileItem.h"
 
 
+#ifdef Q_OS_WIN
+
+#include <QtWin>
+
+QIcon getWindowsIcon( const QString& pathName )
+{
+    SHFILEINFOW shfi;
+    memset( &shfi, 0, sizeof(shfi) );
+    DWORD flags = SHGFI_ICON | SHGFI_USEFILEATTRIBUTES | SHGFI_SMALLICON;
+    SHGetFileInfoW( (LPCWSTR) pathName.utf16(), FILE_ATTRIBUTE_NORMAL, &shfi, sizeof(shfi), flags );
+
+    QPixmap pm = QtWin::fromHICON( shfi.hIcon );
+    DestroyIcon( shfi.hIcon );
+
+    return QIcon( pm );
+}
+#endif
+
+
 WorkingTreeModel::WorkingTreeModel(QObject* parent )
     : QAbstractItemModel( parent )
     , mRootItem( NULL )
@@ -216,7 +235,7 @@ void WorkingTreeModel::update()
         QFileInfo fi( mRepo.basePath() + L'/' + it.key() );
 
 #ifdef Q_OS_WIN
-        file->setIcon( QIcon() );
+        file->setIcon( getWindowsIcon( fi.absoluteFilePath() ) );
 #else
         file->setIcon( ip.icon( fi ) );
 #endif


### PR DESCRIPTION
The commit is taken over from the "old" MacGitver repo:
- [x] function "getWindowsIcon()" -> **ported**
- [x] Can we safely remove the lines in HistoryDiff:L84? -> **ported**
  - The "ComboBox'ed" QTreeView needs some love. As we plan to revisit DiffViewer anyways, I just added some TODO comment to not forget about that.
