### PR TITLE
Module RefsView: reorganize menu actions

### DIFF
--- a/Modules/RefsViews/Branches/BranchesView.cpp
+++ b/Modules/RefsViews/Branches/BranchesView.cpp
@@ -87,10 +87,18 @@ void BranchesView::showContextMenu(const QModelIndex& index, const QPoint& globa
         return;
     }
 
-    Heaven::Menu* menu = 0;
+    Heaven::Menu* menu = nullptr;
     switch (item->type()) {
     case RefItem::Branch:
         menu = menuMnuBranch;
+        break;
+
+    case RefItem::Remote:
+        menu = menuMnuRemote;
+        break;
+
+    case RefItem::Tag:
+        menu = menuMnuTag;
         break;
 
     default:

--- a/Modules/RefsViews/Branches/BranchesView.cpp
+++ b/Modules/RefsViews/Branches/BranchesView.cpp
@@ -88,13 +88,19 @@ void BranchesView::showContextMenu(const QModelIndex& index, const QPoint& globa
     }
 
     Heaven::Menu* menu = 0;
-    if (item->type() == RefItem::Branch) {
-        menu = menuCtxMenuRefsView;
-        //menu->setActivationContext( item );
+    switch (item->type()) {
+    case RefItem::Branch:
+        menu = menuMnuBranch;
+        break;
+
+    default:
+        break;
     }
 
-    if ( menu )
+    if ( menu ) {
+        //menu->setActivationContext( item );
         menu->showPopup( globalPos );
+    }
 }
 
 void BranchesView::onCheckoutRef()

--- a/Modules/RefsViews/Branches/BranchesView.cpp
+++ b/Modules/RefsViews/Branches/BranchesView.cpp
@@ -51,7 +51,7 @@ BranchesView::BranchesView()
     setupActions( this );
 
     setViewName( tr( "References" ) );
-    setToolBar( tbBranchesTB );
+    setToolBar( tbRefsViewTB );
     setWidget( mTree );
 
     setFlags( ConsumesContexts | DataPerContext );

--- a/Modules/RefsViews/Branches/BranchesViewActions.hid
+++ b/Modules/RefsViews/Branches/BranchesViewActions.hid
@@ -35,7 +35,24 @@ Ui BranchesViewActions {
     };
 
     ToolBar RefsViewTB {
-        // placeholder for the real toolbar
+        Action ShowLocalBranches {
+            Text        "Branches";
+            ConnectTo   onShowBranches();
+            Checkable   true;
+            Checked     true;
+        };
+        Action ShowRemotes {
+            Text        "Remotes";
+            ConnectTo   onShowRemotes();
+            Checkable   true;
+            Checked     true;
+        };
+        Action ShowTags {
+            Text        "Tags";
+            ConnectTo   onShowTags();
+            Checkable   true;
+            Checked     true;
+        };
     };
 
     Menu MnuBranch {

--- a/Modules/RefsViews/Branches/BranchesViewActions.hid
+++ b/Modules/RefsViews/Branches/BranchesViewActions.hid
@@ -53,6 +53,7 @@ Ui BranchesViewActions {
     Menu MnuRemote {
         Action      RenameRef;
         Separator;
+
         MergePlace  FetchThisMP;
         Separator;
 

--- a/Modules/RefsViews/Branches/BranchesViewActions.hid
+++ b/Modules/RefsViews/Branches/BranchesViewActions.hid
@@ -46,4 +46,24 @@ Ui BranchesViewActions {
         Action      RemoveRef;
     };
 
+    Menu MnuRemote {
+        Action      RenameRef;
+        Separator;
+        Action      RemoveRef;
+    };
+
+    Menu MnuRemoteBranch {
+        Action      CheckoutRef;
+        Separator;
+
+        Action      RemoveRef;
+    };
+
+    Menu MnuTag {
+        Action      CheckoutRef;
+        Separator;
+
+        Action      RemoveRef;
+    };
+
 };

--- a/Modules/RefsViews/Branches/BranchesViewActions.hid
+++ b/Modules/RefsViews/Branches/BranchesViewActions.hid
@@ -38,10 +38,11 @@ Ui BranchesViewActions {
         // placeholder for the real toolbar
     };
 
-    Menu CtxMenuRefsView {
+    Menu MnuBranch {
         Action      CheckoutRef;
         Action      RenameRef;
         Separator;
+
         Action      RemoveRef;
     };
 

--- a/Modules/RefsViews/Branches/BranchesViewActions.hid
+++ b/Modules/RefsViews/Branches/BranchesViewActions.hid
@@ -34,7 +34,7 @@ Ui BranchesViewActions {
         ConnectTo       onRenameRef();
     };
 
-    ToolBar BranchesTB {
+    ToolBar RefsViewTB {
         // placeholder for the real toolbar
     };
 

--- a/Modules/RefsViews/Branches/BranchesViewActions.hid
+++ b/Modules/RefsViews/Branches/BranchesViewActions.hid
@@ -43,17 +43,27 @@ Ui BranchesViewActions {
         Action      RenameRef;
         Separator;
 
+        MergePlace  FetchMP;
+        MergePlace  PushMP;
+        Separator;
+
         Action      RemoveRef;
     };
 
     Menu MnuRemote {
         Action      RenameRef;
         Separator;
+        MergePlace  FetchThisMP;
+        Separator;
+
         Action      RemoveRef;
     };
 
     Menu MnuRemoteBranch {
         Action      CheckoutRef;
+        Separator;
+
+        MergePlace  FetchThisMP;
         Separator;
 
         Action      RemoveRef;


### PR DESCRIPTION
In the past we had a single context menu, that got applied to every RefItem - independent of it's type. At that time we only differed between a "Reference" and "Pseudo-Item" (aka header/folder).

Nowadays, we have more types available, (e.g. a Remote item). This requires us to split the menu according to the item type. Finally, this allows us to show the "right action at the right place".
- [x] Provide menus for the item types `Branch`, `Remote` and `Tag`.
- [ ] Provide menu for the item type `RemoteBranch`.
  - Has the item type `Branch`. Didn't check yet, but a "sub-type" should be available.
- [x] Provide merge places for fetch & push services.
- [ ] Currently, the "action context" in a "checkout" action is set to a "Branch" item type. This leads to crash (assertion).
  - The checkout operation has to be created according to the item type. This also is subject to change, as we plan to replace `Git::CheckoutOperation` with an `RM::CheckoutService`. If done right, we should be able to simply provide the `item->object()` to RepoMan.
- [x] Provide toolbar actions to hide/show the item types (Branches, Remotes, Tags)
  - [ ] Use icons according to the item type instead of text.
  - [ ] Display toolbar buttons as a "group" -> The buttons should not have a space between them.
